### PR TITLE
Fix import error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
-use std::ffi::{c_char, CStr};
+use std::ffi::CStr;
 use std::fmt::Write;
+use std::os::raw::c_char;
 
 use clap::ArgMatches;
 use eyre::Context;


### PR DESCRIPTION
Need to import `c_char` from `std::os::raw` not `std::ffi`.

Original error message
```
error[E0432]: unresolved import `std::ffi::c_char`
 --> src/main.rs:1:16
  |
1 | use std::ffi::{c_char, CStr};
  |                ^^^^^^ no `c_char` in `ffi`

For more information about this error, try `rustc --explain E0432`.
```

Toolchain version
```
$ cargo --version
cargo 1.63.0 (fd9c4297c 2022-07-01)
```